### PR TITLE
fix unit event message

### DIFF
--- a/pkg/util/interpretabity/pg_interpretability.go
+++ b/pkg/util/interpretabity/pg_interpretability.go
@@ -1,38 +1,20 @@
-/*
-Copyright 2023 The Godel Scheduler Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package interpretabity
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/kubewharf/godel-scheduler/pkg/framework/api"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-// SchedulingFailure describe the reason for unschedulable Pod.
-type SchedulingFailure string
+// SchedulingFailureCategory describe the reason for unschedulable Pod.
+type SchedulingFailureCategory string
 
 const (
 	// UnexpectedError happened during the workflow of Scheduler or Binder.
-	UnexpectedError SchedulingFailure = "UnexpectedError"
+	UnexpectedError SchedulingFailureCategory = "UnexpectedError"
 	// InsufficientResourcesError implies Scheduler doesn't find a schedulable node because of insufficient resources.
-	InsufficientResourcesError SchedulingFailure = "InsufficientResources"
-	// ConcurrencyConflictsError implies Binder can't resolve conflicts from Scheduler instances.
-	ConcurrencyConflictsError SchedulingFailure = "ConcurrencyConflicts"
+	InsufficientResourcesError SchedulingFailureCategory = "InsufficientResources"
 )
 
 // SchedulingPhase describe the scheduling phase.
@@ -40,100 +22,52 @@ type SchedulingPhase string
 
 const (
 	Scheduling SchedulingPhase = "Scheduling"
-	Binding    SchedulingPhase = "Binding"
 )
 
-// UnitSchedulingDetails interpret the scheduling failures for podgroup.
+// UnitSchedulingDetails interpret the scheduling category for podgroup.
 type UnitSchedulingDetails struct {
 	phase          SchedulingPhase
 	allPods        int
-	successfulPods int
-	failedPods     int
-	// for scheduler: unHandledPods = allPods - successfulPods - failedPods
-	// for binder: unHandledPods = allPods - failedPods
-	// There are no successful Pods when binder rejects a PodGroupUnit
-	unHandledPods int
-	// failures records the failure for failed Pods
-	failures map[SchedulingFailure]int
-	// unitError records the failed error of the unit, it's nil if the unit is successful.
-	// It will only be set when assume or applyToCache operation failed.
-	unitError error
+	successfulPods sets.String
 	// podError records the failed error of every failed Pod
 	podError map[string]error
 }
 
-// NewUnitSchedulingDetails returns an interpreter instance.
+// NewUnitSchedulingDetails returns a interpreter instance.
 func NewUnitSchedulingDetails(phase SchedulingPhase, allPods int) *UnitSchedulingDetails {
 	return &UnitSchedulingDetails{
-		phase:   phase,
-		allPods: allPods,
-		// all pods are initialized to unhandled pods
-		unHandledPods: allPods,
-		failures:      make(map[SchedulingFailure]int),
-		podError:      make(map[string]error),
+		phase:          phase,
+		allPods:        allPods,
+		successfulPods: sets.NewString(),
+		podError:       make(map[string]error),
 	}
 }
 
-// AddSuccess adds a successful Pod.
-func (details *UnitSchedulingDetails) AddSuccess() {
+func (details *UnitSchedulingDetails) AddSuccessfulPods(podKey ...string) {
 	if details == nil {
 		return
 	}
-	details.successfulPods++
-	details.unHandledPods--
+	details.successfulPods.Insert(podKey...)
 }
 
-// RemoveNSuccess removes n Pods from successfulPods to failedPods, and adds its error.
-func (details *UnitSchedulingDetails) RemoveNSuccess(n int, err error) {
+func (details *UnitSchedulingDetails) AddPodsError(err error, podKey ...string) {
 	if details == nil {
 		return
 	}
-
-	if n > details.successfulPods {
-		n = details.successfulPods
-	}
-
-	details.successfulPods -= n
-	if err != nil {
-		details.failures[details.errorToFailure(err)] += n
-	}
-}
-
-// SetUnitError sets the failed error of the whole unit.
-func (details *UnitSchedulingDetails) SetUnitError(err error) {
-	if details == nil {
+	if err == nil {
 		return
 	}
 
-	details.unitError = err
-
-	// adjust the failedPods and successfulPods
-	details.failedPods += details.successfulPods
-	details.successfulPods = 0
-
-	// if the whole unit failed due to assume or apply cache operation error,
-	// there is no need to record the error for each pod
-	details.podError = make(map[string]error)
-}
-
-// AddPodError adds a pod scheduling error.
-func (details *UnitSchedulingDetails) AddPodError(podKey string, err error) {
-	if details == nil || err == nil {
-		return
+	for _, key := range podKey {
+		details.podError[key] = err
 	}
 
-	details.podError[podKey] = err
-	details.AddError(err)
+	details.successfulPods.Delete(podKey...)
 }
 
 func (details *UnitSchedulingDetails) GetPodError(podKey string) error {
 	if details == nil {
 		return nil
-	}
-
-	// if the whole unit failed, return the unit error
-	if details.unitError != nil {
-		return details.unitError
 	}
 
 	if err, ok := details.podError[podKey]; ok {
@@ -143,9 +77,9 @@ func (details *UnitSchedulingDetails) GetPodError(podKey string) error {
 	return nil
 }
 
-// errorToFailure converts error to SchedulingFailure. The caller has to make sure the error is not nil.
-func (details *UnitSchedulingDetails) errorToFailure(err error) SchedulingFailure {
-	if details == nil {
+// errorToFailureCategory converts error to SchedulingFailureCategory. The caller has to make sure the error is not nil.
+func errorToFailureCategory(err error) SchedulingFailureCategory {
+	if err == nil {
 		return UnexpectedError
 	}
 
@@ -153,59 +87,22 @@ func (details *UnitSchedulingDetails) errorToFailure(err error) SchedulingFailur
 	case api.PreemptionError:
 		return InsufficientResourcesError
 	case *api.FitError:
-		if details.phase == Scheduling {
-			return InsufficientResourcesError
-		} else {
-			return ConcurrencyConflictsError
-		}
+		return InsufficientResourcesError
 	default:
 		return UnexpectedError
 	}
 }
 
-// AddError adds a failed Pod, and records failure according to error type.
-func (details *UnitSchedulingDetails) AddError(podError error) {
+func (details *UnitSchedulingDetails) aggregatePodErrors() map[SchedulingFailureCategory]int {
 	if details == nil {
-		return
+		return nil
 	}
 
-	if podError == nil {
-		return
+	category := make(map[SchedulingFailureCategory]int)
+	for _, err := range details.podError {
+		category[errorToFailureCategory(err)]++
 	}
-
-	details.failures[details.errorToFailure(podError)]++
-	details.failedPods++
-	details.unHandledPods--
-	return
-}
-
-// FailureReason returns scheduling failure reason.
-// It describes what kind of failure has happened during the scheduling.
-// If all Pods are successful, returns "".
-func (details *UnitSchedulingDetails) FailureReason() string {
-	if details == nil {
-		return ""
-	}
-
-	if details.successfulPods == details.allPods {
-		return ""
-	}
-
-	// all Pods quick failed, it must something internal error.
-	if details.unHandledPods == details.allPods {
-		return fmt.Sprintf("[%v]: %v", details.phase, UnexpectedError)
-	}
-
-	if details.failedPods > 0 {
-		var failures []string
-		for r := range details.failures {
-			failures = append(failures, string(r))
-		}
-
-		return fmt.Sprintf("[%v]: %v", details.phase, strings.Join(failures, ", "))
-	}
-
-	return ""
+	return category
 }
 
 // FailureMessage returns the detailed failure message about the scheduling.
@@ -215,26 +112,16 @@ func (details *UnitSchedulingDetails) FailureMessage() string {
 		return ""
 	}
 
-	var failureDetails []string
-	for r, d := range details.failures {
-		failureDetails = append(failureDetails, fmt.Sprintf("%v:%d", r, d))
-	}
+	successfulPods := len(details.successfulPods)
+	failedPods := len(details.podError)
+	unHandledPods := details.allPods - successfulPods - failedPods
 
-	failureMsg := "[No failure]"
-	if msg := strings.Join(failureDetails, ", "); msg != "" {
-		failureMsg = "[" + msg + "]"
-	}
-
-	return fmt.Sprintf("allPods=%d, unHandledPods=%d, successfulPods=%d, failedPods=%d %s",
-		details.allPods, details.unHandledPods, details.successfulPods, details.failedPods, failureMsg)
+	return fmt.Sprintf("allPods=%d, unHandledPods=%d, successfulPods=%d, failedPods=%d",
+		details.allPods, unHandledPods, successfulPods, failedPods)
 }
 
 func (details *UnitSchedulingDetails) GetErrors() []error {
 	errs := []error{}
-	if details.unitError != nil {
-		errs = append(errs, details.unitError)
-	}
-
 	for podKey, err := range details.podError {
 		errs = append(errs, fmt.Errorf("pod: %v, err: %v", podKey, err))
 	}


### PR DESCRIPTION
1. 修复 event message 中 pods 计数为负数的异常；
2. 移除 event message unit 失败归因。

```
# before:
Warning  FailToScheduleUnit  2s    godel-scheduler     Failed to schedule unit. unit message:uint key=PodGroupUnit/default/fifo-podgroup-0, ever scheduled=false, allMember=5, minMember=5; failure message:allPods=0, unHandledPods=-5, successfulPods=0, failedPods=5 [UnexpectedError:5] 

# after: 
Warning  FailToScheduleUnit  1s    godel-scheduler     Failed to schedule unit. unit message:uint key=PodGroupUnit/default/fifo-podgroup-0, ever scheduled=false, allMember=5, minMember=5; failure message:allPods=5, unHandledPods=0, successfulPods=0, failedPods=5
```