### PR TITLE
improve build process for local quick-start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ all build:
 	$(MYMAKE) go build $(WHAT)
 endif
 
-docker-images: build e2e
+docker-images:
 	./hack/make-rules/build-images.sh
 
 local-up: docker-images

--- a/docker/godel-local.Dockerfile
+++ b/docker/godel-local.Dockerfile
@@ -1,4 +1,27 @@
-FROM debian:stable-slim
+# Define the builder stage
+FROM golang:1.21 as builder
+
+WORKDIR /workspace
+
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# Copy the go source
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+COPY hack/ hack/
+COPY vendor/ vendor/
+COPY Makefile Makefile
+COPY Makefile.expansion Makefile.expansion
+
+RUN export GO_BUILD_PLATFORMS=linux/amd64 && make build
+
+FROM debian:bookworm
+RUN apt-get update && \
+    apt-get install -y binutils && \
+    apt-get clean && \
+    ldd --version
 
 WORKDIR /root
-COPY bin/linux_amd64/* /usr/local/bin/
+COPY --from=builder /workspace/bin/linux_amd64/* /usr/local/bin/

--- a/hack/make-rules/build-images.sh
+++ b/hack/make-rules/build-images.sh
@@ -3,9 +3,6 @@
 # error on exit
 set -e
 
-# verbose for debugging
-set -x
-
 # Main of the script
 DOCKERFILE_DIR="docker/"
 LOCAL_DOCKERFILE="godel-local.Dockerfile"
@@ -15,14 +12,20 @@ echo "Building docker image(s) for ${1}..."
 docker container prune -f || true;
 docker image prune -f || true
 
+function cleanup_godel_images() {
+  for i in $(docker images | grep "${1}" | awk "{print \$3}");
+  do
+    docker rmi "$i" -f;
+  done
+}
+
 build_image() {
   local file=${1}
   REPO=$(basename "$file");
   REPO=${REPO%.*};
   REV=$(git log --pretty=format:'%h' -n 1);
   TAG=${REPO}:${REV}
-  docker rmi "${TAG}" || true;
-  docker rmi "${REPO}:latest" || true
+  cleanup_godel_images "${REPO}"
   docker build -t "${TAG}"  -f "$file" ./;
   docker tag "${TAG}" "${REPO}:latest"
 }

--- a/manifests/base/deployment/binder.yaml
+++ b/manifests/base/deployment/binder.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: binder
           image: godel-local:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Never
           command: ["/usr/local/bin/binder"]
           args:
             - "--leader-elect=false"

--- a/manifests/base/deployment/dispatcher.yaml
+++ b/manifests/base/deployment/dispatcher.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: dispatcher
           image: godel-local:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Never
           command: ["/usr/local/bin/dispatcher"]
           args:
             - "--leader-elect=false"

--- a/manifests/base/deployment/scheduler.yaml
+++ b/manifests/base/deployment/scheduler.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: scheduler
           image: godel-local:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Never
           command: ["/usr/local/bin/scheduler"]
           args:
             - "--leader-elect=false"


### PR DESCRIPTION
1. Move build process from local to Dockerfile;
2. Pin a version for debian (bookworm) instead of using the stable-slim tag;
3. Add cleaning up for godel images;
4. Change imagePullPolicy to Never, because the godel-local image should be loaded before creating godel components.